### PR TITLE
Fix all current pre-patch errors for Midnight 12.0.0

### DIFF
--- a/RangeDisplay.lua
+++ b/RangeDisplay.lua
@@ -230,22 +230,34 @@ end
 
 local function checkTarget(ud)
   local unit = ud.unit
-  if not UnitExists(unit) or UnitIsUnit(unit, "player") then
-    return nil
-  end
-  if UnitIsDeadOrGhost(unit) then
+  if not unit then return nil end
+
+  local success, result = pcall(function()
+    if not UnitExists(unit) or UnitIsUnit(unit, "player") then
+      return nil
+    end
+
+    if UnitIsDeadOrGhost(unit) then
+      ud.useSound = false
+      return not ud.db.enemyOnly
+    end
+
+    if UnitCanAttack("player", unit) then
+      ud.useSound = not mute
+      return true
+    elseif UnitCanAssist("player", unit) then
+      ud.useSound = not mute and not ud.db.warnEnemyOnly
+      return not ud.db.enemyOnly
+    end
+    
     ud.useSound = false
     return not ud.db.enemyOnly
-  end
-  if UnitCanAttack("player", unit) then
-    ud.useSound = not mute
-    return true
-  elseif UnitCanAssist("player", unit) then
-    ud.useSound = not mute and not ud.db.warnEnemyOnly
-    return not ud.db.enemyOnly
+  end)
+
+  if success then
+    return result
   else
-    ud.useSound = false
-    return not ud.db.enemyOnly
+    return true 
   end
 end
 

--- a/RangeDisplay.toc
+++ b/RangeDisplay.toc
@@ -1,4 +1,4 @@
-## Interface: 110207,11508,50503,20505
+## Interface: 120001,120000,110207,11508,50503,20505
 
 ## Title: RangeDisplay
 ## Author: mitch0


### PR DESCRIPTION
1. Prevent secret value errors
2. Restore display values for target
 
- Handles value requests in a function to prevent/handle errors if the request returns a secret value.
- Displays range even if a secret value was returned, while preventing errors.
- Works in dungeons as well as outside! Tested all.
- No visual cues of fps drops or other performance issues related to this change.

Issues this closes:
- #39, #38 -- [On CurseForge](https://legacy.curseforge.com/wow/addons/range-display/issues)
- and all of comments on curse too, because they didn't submit issues neither on github or curse

____________
I'm not a pro at `lua` so please do more testing on your end. Just wanted to help. So far it works on my end and there are no errors. Hope it helps!

Cheers!